### PR TITLE
feat(infra): separate Docker Compose configurations for different environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ Cargo.lock
 .env.test.local
 .env.production.local
 
+# Infrastructure environment files
+infra/.env.dev
+infra/.env.staging
+infra/.env.prod
+infra/.env
+
 # Logs
 logs/
 *.log

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,80 @@
+# Environment Variables Template
+# Copy this file and rename based on environment:
+# - .env.dev (for development)
+# - .env.staging (for staging)
+# - .env.prod (for production)
+
+# ========================================
+# DEVELOPMENT ENVIRONMENT (.env.dev)
+# ========================================
+
+# PostgreSQL Configuration (Local Docker)
+POSTGRES_DATABASE=parapara_comic_dev
+POSTGRES_USER=user
+POSTGRES_PASSWORD=password
+
+# Application Configuration
+NODE_ENV=development
+VITE_API_URL=http://localhost:8080
+RUST_LOG=debug
+RUST_BACKTRACE=full
+
+# Port Configuration
+FRONTEND_PORT=5173
+BACKEND_PORT=8080
+POSTGRES_PORT=5432
+
+# ========================================
+# STAGING ENVIRONMENT (.env.staging)
+# ========================================
+
+# SSH Tunnel Configuration for Database Access
+BASTION_USER=ubuntu
+BASTION_HOST=your-bastion-host.amazonaws.com
+BASTION_PORT=22
+BASTION_SSH_KEY_PATH=~/.ssh/your-key.pem
+DB_TARGET_HOST=your-rds-instance.region.rds.amazonaws.com
+DB_TARGET_PORT=5432
+LOCAL_TUNNEL_PORT=5433
+SSH_STRICT_HOST_KEY_CHECKING=yes
+
+# PostgreSQL Configuration (via SSH tunnel)
+POSTGRES_HOST=127.0.0.1
+POSTGRES_PORT=5433
+POSTGRES_DATABASE=parapara_comic_staging
+POSTGRES_USER=staging_user
+POSTGRES_PASSWORD=your_staging_password
+
+# Application Configuration
+NODE_ENV=staging
+VITE_API_URL=http://localhost:8080
+RUST_LOG=info,api=debug
+RUST_BACKTRACE=1
+
+# Port Configuration
+FRONTEND_PORT=3000
+BACKEND_PORT=8080
+
+# ========================================
+# PRODUCTION ENVIRONMENT (.env.prod)
+# ========================================
+
+# PostgreSQL Configuration (RDS or managed database)
+POSTGRES_HOST=your-production-db.region.rds.amazonaws.com
+POSTGRES_PORT=5432
+POSTGRES_DATABASE=parapara_comic_prod
+POSTGRES_USER=prod_user
+POSTGRES_PASSWORD=your_production_password
+DATABASE_URL=postgresql://prod_user:your_production_password@your-production-db.region.rds.amazonaws.com:5432/parapara_comic_prod
+
+# Application Configuration
+NODE_ENV=production
+VITE_API_URL=https://api.yourdomain.com
+RUST_LOG=warn,api=info
+RUST_BACKTRACE=0
+
+# Port Configuration
+FRONTEND_PORT=80
+BACKEND_PORT=8080
+NGINX_HTTP_PORT=80
+NGINX_HTTPS_PORT=443

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,4 +1,23 @@
-.PHONY: dev prod down clean logs ps
+.PHONY: help dev staging prod down clean logs ps
+
+# Default target - show help
+help:
+	@echo "Available commands:"
+	@echo "  make dev          - Start development environment"
+	@echo "  make dev-build    - Build and start development environment"
+	@echo "  make dev-down     - Stop development environment"
+	@echo "  make staging      - Start staging environment"
+	@echo "  make staging-build- Build and start staging environment"
+	@echo "  make staging-down - Stop staging environment"
+	@echo "  make prod         - Start production environment"
+	@echo "  make prod-build   - Build and start production environment"
+	@echo "  make prod-down    - Stop production environment"
+	@echo "  make down         - Stop all environments"
+	@echo "  make clean        - Stop and remove all volumes"
+	@echo "  make logs-dev     - Show development logs"
+	@echo "  make logs-staging - Show staging logs"
+	@echo "  make logs-prod    - Show production logs"
+	@echo "  make ps           - Show running containers for all environments"
 
 # Development environment
 dev:
@@ -10,6 +29,22 @@ dev-build:
 dev-down:
 	docker compose -f docker-compose.dev.yml down
 
+dev-restart:
+	docker compose -f docker-compose.dev.yml restart
+
+# Staging environment
+staging:
+	docker compose -f docker-compose.staging.yml up -d
+
+staging-build:
+	docker compose -f docker-compose.staging.yml up -d --build
+
+staging-down:
+	docker compose -f docker-compose.staging.yml down
+
+staging-restart:
+	docker compose -f docker-compose.staging.yml restart
+
 # Production environment
 prod:
 	docker compose -f docker-compose.prod.yml up -d
@@ -20,21 +55,50 @@ prod-build:
 prod-down:
 	docker compose -f docker-compose.prod.yml down
 
+prod-restart:
+	docker compose -f docker-compose.prod.yml restart
+
 # Common commands
 down:
 	docker compose -f docker-compose.dev.yml down
+	docker compose -f docker-compose.staging.yml down
 	docker compose -f docker-compose.prod.yml down
 
 clean:
 	docker compose -f docker-compose.dev.yml down -v
+	docker compose -f docker-compose.staging.yml down -v
 	docker compose -f docker-compose.prod.yml down -v
 
+# Logs
 logs-dev:
 	docker compose -f docker-compose.dev.yml logs -f
+
+logs-staging:
+	docker compose -f docker-compose.staging.yml logs -f
 
 logs-prod:
 	docker compose -f docker-compose.prod.yml logs -f
 
+# Status
 ps:
-	docker compose -f docker-compose.dev.yml ps
-	docker compose -f docker-compose.prod.yml ps
+	@echo "=== Development ==="
+	@docker compose -f docker-compose.dev.yml ps
+	@echo "\n=== Staging ==="
+	@docker compose -f docker-compose.staging.yml ps
+	@echo "\n=== Production ==="
+	@docker compose -f docker-compose.prod.yml ps
+
+# Database access
+db-dev:
+	docker compose -f docker-compose.dev.yml exec postgres psql -U dev_user -d comic_dev
+
+db-staging:
+	docker compose -f docker-compose.staging.yml exec backend sh -c 'psql $$DATABASE_URL'
+
+# Backup & Restore (Development)
+backup-dev:
+	docker compose -f docker-compose.dev.yml exec postgres pg_dump -U dev_user comic_dev > backup_dev_$$(date +%Y%m%d_%H%M%S).sql
+
+restore-dev:
+	@read -p "Enter backup file name: " file; \
+	docker compose -f docker-compose.dev.yml exec -T postgres psql -U dev_user comic_dev < $$file

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,44 +1,23 @@
-version: '3.8'
-
 services:
-  ssh-tunnel:
-    image: alpine:3.20
-    network_mode: host
-    volumes:
-      - ${BASTION_SSH_KEY_PATH}:/ssh/id_rsa:ro
+  postgres:
+    image: postgres:latest
+    env_file:
+      - .env.dev
     environment:
-      BASTION_USER: ${BASTION_USER}
-      BASTION_HOST: ${BASTION_HOST}
-      BASTION_PORT: ${BASTION_PORT:-22}
-      DB_TARGET_HOST: ${DB_TARGET_HOST}
-      DB_TARGET_PORT: ${DB_TARGET_PORT:-5432}
-      LOCAL_TUNNEL_PORT: ${LOCAL_TUNNEL_PORT:-5433}
-      SSH_STRICT_HOST_KEY_CHECKING: ${SSH_STRICT_HOST_KEY_CHECKING:-no}
+      POSTGRES_DB: ${POSTGRES_DATABASE}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - app-network
     healthcheck:
-      test: ["CMD", "nc", "-z", "127.0.0.1", "${LOCAL_TUNNEL_PORT:-5433}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s
-      timeout: 3s
-      retries: 20
-      start_period: 10s
-    command:
-      - sh
-      - -lc
-      - |
-        set -e
-        apk add --no-cache openssh-client netcat-openbsd
-        # Copy key to a writable path and fix permissions
-        cp /ssh/id_rsa /tmp/id_rsa
-        chmod 600 /tmp/id_rsa
-        # Start persistent local port-forward via bastion
-        exec ssh -NT \
-          -o ServerAliveInterval=30 \
-          -o ServerAliveCountMax=6 \
-          -o ExitOnForwardFailure=yes \
-          -o StrictHostKeyChecking=$${SSH_STRICT_HOST_KEY_CHECKING} \
-          -i /tmp/id_rsa \
-          -p $${BASTION_PORT:-22} \
-          -L 127.0.0.1:$${LOCAL_TUNNEL_PORT:-5433}:$${DB_TARGET_HOST}:$${DB_TARGET_PORT:-5432} \
-          $${BASTION_USER}@$${BASTION_HOST}
+      timeout: 5s
+      retries: 5
 
   frontend:
     image: node:24-alpine
@@ -47,10 +26,9 @@ services:
       - ../frontend:/app
       - /app/node_modules
     ports:
-      - "5173:5173"
-    environment:
-      - NODE_ENV=development
-      - VITE_API_URL=http://localhost:8080
+      - "${FRONTEND_PORT:-5173}:5173"
+    env_file:
+      - .env.dev
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
     networks:
       - app-network
@@ -58,36 +36,41 @@ services:
   backend:
     image: rust:1.89.0
     working_dir: /app
-    network_mode: host
     volumes:
       - ../backend:/app
       - cargo-cache:/usr/local/cargo/registry
       - cargo-git:/usr/local/cargo/git
       - cargo-bin:/usr/local/cargo/bin
       - target-cache:/app/target
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
     env_file:
-      - ../backend/.env
+      - .env.dev
     environment:
-      - POSTGRES_HOST=${POSTGRES_HOST}
-      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
       - POSTGRES_DATABASE=${POSTGRES_DATABASE}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DATABASE}
+      - RUST_LOG=${RUST_LOG}
+      - RUST_BACKTRACE=${RUST_BACKTRACE}
     command: >
       sh -c "
-      export DATABASE_URL=\"postgresql://\$${POSTGRES_USER}:\$${POSTGRES_PASSWORD}@127.0.0.1:\$${LOCAL_TUNNEL_PORT}/\$${POSTGRES_DATABASE}\" &&
-      echo \"DATABASE_URL: \$$DATABASE_URL\" &&
       which cargo-watch || cargo install cargo-watch &&
       cargo watch -x run"
     depends_on:
-      ssh-tunnel:
+      postgres:
         condition: service_healthy
+    networks:
+      - app-network
 
 networks:
   app-network:
     driver: bridge
 
 volumes:
+  postgres-data:
   cargo-cache:
   cargo-git:
   cargo-bin:

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,51 +1,87 @@
-version: '3.8'
-
 services:
   frontend:
-    image: node:24-alpine
-    working_dir: /app
-    volumes:
-      - ../frontend:/app
-      - /app/node_modules
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+    image: comic-frontend:latest
     ports:
-      - "3000:3000"
-    environment:
-      - NODE_ENV=production
-      - VITE_API_URL=http://backend:8080
-    command: sh -c "npm install && npm run build && npm run preview -- --host 0.0.0.0 --port 3000"
+      - "${FRONTEND_PORT:-80}:80"
+    env_file:
+      - .env.prod
     networks:
       - app-network
     depends_on:
       - backend
-
-  backend:
-    image: rust:1.89.0
-    working_dir: /app
-    volumes:
-      - ../backend:/app
-      - cargo-cache:/usr/local/cargo/registry
-      - cargo-git:/usr/local/cargo/git
-      - target-cache:/app/target
-    ports:
-      - "8080:8080"
-    environment:
-      - RUST_LOG=info
-      - RUST_BACKTRACE=0
-    command: sh -c "cargo build --release && ./target/release/api"
-    networks:
-      - app-network
+    restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:80"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 256M
+
+  backend:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
+    image: comic-backend:latest
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
+    env_file:
+      - .env.prod
+    networks:
+      - app-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 1024M
+        reservations:
+          cpus: '1.0'
+          memory: 512M
+
+  nginx:
+    image: nginx:alpine
+    env_file:
+      - .env.prod
+    ports:
+      - "${NGINX_HTTP_PORT:-80}:80"
+      - "${NGINX_HTTPS_PORT:-443}:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    networks:
+      - app-network
+    depends_on:
+      - frontend
+      - backend
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "nginx", "-t"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
 networks:
   app-network:
     driver: bridge
-
-volumes:
-  cargo-cache:
-  cargo-git:
-  target-cache:
+    ipam:
+      config:
+        - subnet: 172.20.0.0/24

--- a/infra/docker-compose.staging.yml
+++ b/infra/docker-compose.staging.yml
@@ -1,0 +1,82 @@
+services:
+  ssh-tunnel:
+    image: alpine:3.20
+    network_mode: host
+    env_file:
+      - .env.staging
+    volumes:
+      - ${BASTION_SSH_KEY_PATH}:/ssh/id_rsa:ro
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "${LOCAL_TUNNEL_PORT:-5433}"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+    command:
+      - sh
+      - -lc
+      - |
+        set -e
+        apk add --no-cache openssh-client netcat-openbsd
+        # Copy key to a writable path and fix permissions
+        cp /ssh/id_rsa /tmp/id_rsa
+        chmod 600 /tmp/id_rsa
+        # Start persistent local port-forward via bastion
+        exec ssh -NT \
+          -o ServerAliveInterval=30 \
+          -o ServerAliveCountMax=6 \
+          -o ExitOnForwardFailure=yes \
+          -o StrictHostKeyChecking=$${SSH_STRICT_HOST_KEY_CHECKING} \
+          -i /tmp/id_rsa \
+          -p $${BASTION_PORT:-22} \
+          -L 127.0.0.1:$${LOCAL_TUNNEL_PORT:-5433}:$${DB_TARGET_HOST}:$${DB_TARGET_PORT:-5432} \
+          $${BASTION_USER}@$${BASTION_HOST}
+
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile.staging
+    image: comic-frontend:staging
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+    env_file:
+      - .env.staging
+    networks:
+      - app-network
+    depends_on:
+      - backend
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  backend:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile.staging
+    image: comic-backend:staging
+    network_mode: host
+    env_file:
+      - .env.staging
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${LOCAL_TUNNEL_PORT}/${POSTGRES_DATABASE}
+    depends_on:
+      ssh-tunnel:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  cargo-cache:
+  cargo-git:
+  target-cache:


### PR DESCRIPTION
## Summary
Refactored Docker Compose configurations to support three distinct environments as specified in #7:
- **Development**: Local PostgreSQL with hot-reload
- **Staging**: SSH tunnel to production database for debugging
- **Production**: Direct connection with optimizations

## Changes
- ✅ Created `docker-compose.dev.yml` with local PostgreSQL container (latest tag)
- ✅ Added `docker-compose.staging.yml` with SSH tunnel configuration
- ✅ Updated `docker-compose.prod.yml` with production optimizations and Nginx
- ✅ Standardized environment variable management using `env_file` directive
- ✅ Created separate `.env` files for each environment
- ✅ Updated `.env.example` with comprehensive templates
- ✅ Enhanced Makefile with commands for all environments
- ✅ Added environment files to `.gitignore`

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)